### PR TITLE
Fix for Keys remounting

### DIFF
--- a/components/Player/Piano/index.tsx
+++ b/components/Player/Piano/index.tsx
@@ -66,6 +66,75 @@ type KeyProps = {
   id: number
   colour: string
   x: number
+  pedal: boolean
+  play: (id: number) => void
+  stop: (id: number) => void
+  currentNotes: Array<number>
+}
+
+function handleKeyAction(event: KeyboardEvent, callback: () => void) {
+  if (event.key === " " || event.code === "Space") {
+    callback()
+    event.preventDefault()
+  }
+}
+
+function Key({ colour, id, x, pedal, play, stop, currentNotes }: KeyProps) {
+  const playNote = () => (pedal ? null : play(id))
+  const stopNote = () => (pedal ? null : stop(id))
+
+  function toggleNote(id: number) {
+    if (!pedal) return
+    if (!currentNotes.includes(id)) {
+      play(id)
+    } else {
+      stop(id)
+    }
+  }
+  const props = {
+    className: cx(styles.key, {
+      [styles.pressed]: currentNotes.includes(id)
+    }),
+    onClick: () => toggleNote(id),
+    onMouseDown: playNote,
+    role: "button",
+    onMouseOut: stopNote,
+    onMouseUp: stopNote,
+    onKeyPress: (e: KeyboardEvent) => handleKeyAction(e, () => toggleNote(id)),
+    onKeyDown: (e: KeyboardEvent) => handleKeyAction(e, playNote),
+    onKeyUp: (e: KeyboardEvent) => handleKeyAction(e, stopNote),
+    tabIndex: x + 10,
+    key: id,
+    "data-keyid": id
+  }
+
+  /* Note to reader: ordinarily I'd use a button for stuff like this, but you can't have a button inside an SVG */
+  return colour === "w" ? (
+    // @ts-expect-error
+    <g {...props}>
+      <path
+        d={`M${
+          x + Widths.w
+        },141.531l0,-116.531l-24,0l0,116.531c0,1.915,1.554,3.469,3.469,3.469l17.062,0c1.915,0,3.469,-1.554,3.469,-3.469z`}
+        fill="#ebebeb"
+      />
+      <path
+        d={`M${
+          x + Widths.w
+        },141.531l0,-116.531l-24,0l0,116.531c0,1.915,1.554,3.469,3.469,3.469l17.062,0c1.915,0,3.469,-1.554,3.469,-3.469zm-1,-113.062l0,113.062c0,1.363,-1.106,2.469,-2.469,2.469l-17.062,0c-1.363,0,-2.469,-1.106,-2.469,-2.469l0,-115.531l22,0c0,0,0,2.469,0,2.469z`}
+        className={styles.outline}
+      />
+    </g>
+  ) : (
+    // @ts-expect-errorw
+    <g {...props}>
+      <path
+        d={`M${
+          x + Widths.b
+        },94.919v-69.919h-16.8v69.919c0,1.149,1.088,2.081,2.428,2.081h11.944c1.34,0,2.428,-0.932,2.428,-2.081z`}
+      />
+    </g>
+  )
 }
 
 export default function Piano({
@@ -87,69 +156,11 @@ export default function Piano({
     keyColour === "w" ? whiteKeys.push(key) : blackKeys.push(key)
   }
 
-  function handleKeyAction(event: KeyboardEvent, callback: () => void) {
-    if (event.key === " " || event.code === "Space") {
-      callback()
-    }
-  }
-
-  function Key({ colour, id, x }: KeyProps) {
-    const playNote = () => (pedal ? null : play(id))
-    const stopNote = () => (pedal ? null : stop(id))
-    const props = {
-      className: cx(styles.key, {
-        [styles.pressed]: currentNotes.includes(id)
-      }),
-      onClick: () => toggleNote(id),
-      onMouseDown: playNote,
-      role: "button",
-      onMouseOut: stopNote,
-      onMouseUp: stopNote,
-      onKeyPress: (e: KeyboardEvent) =>
-        handleKeyAction(e, () => toggleNote(id)),
-      onKeyDown: (e: KeyboardEvent) => handleKeyAction(e, playNote),
-      onKeyUp: (e: KeyboardEvent) => handleKeyAction(e, stopNote),
-      tabIndex: x + 10,
-      key: id,
-      "data-keyid": id
-    }
-
-    /* Note to reader: ordinarily I'd use a button for stuff like this, but you can't have a button inside an SVG */
-    return colour === "w" ? (
-      // @ts-expect-error
-      <g {...props}>
-        <path
-          d={`M${
-            x + Widths.w
-          },141.531l0,-116.531l-24,0l0,116.531c0,1.915,1.554,3.469,3.469,3.469l17.062,0c1.915,0,3.469,-1.554,3.469,-3.469z`}
-          fill="#ebebeb"
-        />
-        <path
-          d={`M${
-            x + Widths.w
-          },141.531l0,-116.531l-24,0l0,116.531c0,1.915,1.554,3.469,3.469,3.469l17.062,0c1.915,0,3.469,-1.554,3.469,-3.469zm-1,-113.062l0,113.062c0,1.363,-1.106,2.469,-2.469,2.469l-17.062,0c-1.363,0,-2.469,-1.106,-2.469,-2.469l0,-115.531l22,0c0,0,0,2.469,0,2.469z`}
-          className={styles.outline}
-        />
-      </g>
-    ) : (
-      // @ts-expect-errorw
-      <g {...props}>
-        <path
-          d={`M${
-            x + Widths.b
-          },94.919v-69.919h-16.8v69.919c0,1.149,1.088,2.081,2.428,2.081h11.944c1.34,0,2.428,-0.932,2.428,-2.081z`}
-        />
-      </g>
-    )
-  }
-
-  function toggleNote(id: number) {
-    if (!pedal) return
-    if (!currentNotes.includes(id)) {
-      play(id)
-    } else {
-      stop(id)
-    }
+  const keyProps = {
+    pedal,
+    play,
+    stop,
+    currentNotes
   }
 
   const width = whiteKeys.length * Widths.w + 20
@@ -176,12 +187,12 @@ export default function Piano({
       </g>
       <g className={styles.white}>
         {whiteKeys.map((k) => (
-          <Key colour="w" x={k.x} id={k.id} key={k.id} />
+          <Key colour="w" x={k.x} id={k.id} key={k.id} {...keyProps} />
         ))}
       </g>
       <g className={styles.black}>
         {blackKeys.map((k) => (
-          <Key colour="b" x={k.x} id={k.id} key={k.id} />
+          <Key colour="b" x={k.x} id={k.id} key={k.id} {...keyProps} />
         ))}
       </g>
     </svg>

--- a/components/Player/Piano/index.tsx
+++ b/components/Player/Piano/index.tsx
@@ -80,7 +80,7 @@ function handleKeyAction(event: KeyboardEvent, callback: () => void) {
 }
 
 function Key({ colour, id, x, pedal, play, stop, currentNotes }: KeyProps) {
-  const playNote = () => (pedal ? null : play(id))
+  const playNote = () => (pedal || currentNotes.includes(id) ? null : play(id))
   const stopNote = () => (pedal ? null : stop(id))
 
   function toggleNote(id: number) {


### PR DESCRIPTION
Moved Key component outside of Piano to avoid re-mounting on every render. 

Noticed that play() gets called repeatedly when holding down space so have put a check in to see if it's already playing before calling. 